### PR TITLE
默认使用通达信请求仓位信息时返回dict较为合理(?)

### DIFF
--- a/shipane_sdk/client.py
+++ b/shipane_sdk/client.py
@@ -84,7 +84,8 @@ class Client(object):
 
     def get_statuses(self, timeout=None):
         request = Request('GET', self.__create_url(None, 'statuses'))
-        self.__send_request(request, timeout)
+        response = self.__send_request(request, timeout)
+        return response.json()
 
     def get_account(self, client=None, timeout=None):
         request = Request('GET', self.__create_url(client, 'accounts'))

--- a/shipane_sdk/client.py
+++ b/shipane_sdk/client.py
@@ -97,7 +97,7 @@ class Client(object):
         request.headers['Accept'] = media_type.value
         response = self.__send_request(request, timeout)
         json = response.json()
-        if media_type == MediaType.DEFAULT:
+        if media_type != MediaType.DEFAULT:
             sub_accounts = pd.DataFrame(json['subAccounts']).T
             positions = pd.DataFrame(json['dataTable']['rows'], columns=json['dataTable']['columns'])
             portfolio = {'sub_accounts': sub_accounts, 'positions': positions}


### PR DESCRIPTION
使用时发现使用通达信取仓位时返回奇怪的格式，猜测应该是直接返回json(dict)较为合理。

另外不知道为什么我这次只改了一行（99行和100行那里），但是pull request的时候显示我还改了87-88行（这是我上次pull request时候改的地方）。

谢谢。
